### PR TITLE
Add NPM packaging file

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+const EquivalentXml = require('./src/equivalent-xml').EquivalentXml;
+
+exports = {
+  EquivalentXml: EquivalentXml
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "equivalent-xml",
+  "version": "1.0.0",
+  "description": "XML comparison library",
+  "main": "index.js",
+  "scripts": {
+    "test": "jasmine"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/theozaurus/equivalent-xml-js.git"
+  },
+  "keywords": [
+    "XML",
+    "comparison"
+  ],
+  "author": "https://github.com/theozaurus",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/theozaurus/equivalent-xml-js/issues"
+  },
+  "homepage": "https://github.com/theozaurus/equivalent-xml-js#readme"
+}

--- a/src/equivalent-xml.js
+++ b/src/equivalent-xml.js
@@ -1,6 +1,6 @@
 //= require underscore.js
 
-EquivalentXml = (function(){
+exports.EquivalentXml = (function(){
   var canonical_name = function(node){
     return node.namespaceURI + ':' + node.localName;
   };


### PR DESCRIPTION
Run `npm init` with the following inputs to allow this library to be consumed by NPM:

1. package name: (equivalent-xml) 
2. version: (1.0.0) 
3. description: XML comparison library
4. entry point: (index.js) 
5. test command: jasmine
6. git repository: (https://github.com/Redmart/equivalent-xml-js.git) https://github.com/theozaurus/equivalent-xml-js.git
7. keywords: XML, comparison
8. author: https://github.com/theozaurus
9. license: (ISC) MIT
